### PR TITLE
✨ Updates for use with ACL tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ promiscuous_gs = find_gfs_with_extra_contributors(
 
 ```Python
 # Hide all visible families in study SD_DYPMEHHF and all of their descendants.
+# Genomic files receive the specified acl.
 # This and unhide_descendants_by_filter are not symmetrical.
-hide_descendants_by_filter(host, "families", {"study_id": "SD_DYPMEHHF", "visible": True})
+hide_descendants_by_filter(
+  host, "families", {"study_id": "SD_DYPMEHHF", "visible": True}, gf_acl=["SD_DYPMEHHF", "phs001436.c999"]
+)
 ```
 
 ```Python
@@ -94,9 +97,12 @@ unhide_descendants_by_filter(host, "families", {"study_id": "SD_DYPMEHHF", "visi
 `descendants.py` also provides wrapper functions hiding/unhiding descendants by KF ID(s):
 
 ```Python
-# Hide these families and all of their descendants.
+# Hide these families and all of their descendants. Genomic files receive the
+# specified acl.
 # This and unhide_descendants_by_kfids are not symmetrical.
-hide_descendants_by_kfids(host, "families", ["FM_12345678", "FM_87654321"])
+hide_descendants_by_kfids(
+  host, "families", ["FM_12345678", "FM_87654321"], gf_acl=["SD_DYPMEHHF", "phs001436.c999"]
+)
 ```
 
 ```Python
@@ -137,8 +143,8 @@ patch_things_with_func(host, things, my_patch_func)
 ```
 
 ```Python
-# Hide the given KFIDs
-hide_kfids(host, ["PT_12345678", "BS_99999999"])
+# Hide the given KFIDs and assign an empty acl to the hidden genomic file
+hide_kfids(host, ["PT_12345678", "GF_99999999"], gf_acl=[])
 ```
 
 ```Python

--- a/kf_utils/dataservice/descendants.py
+++ b/kf_utils/dataservice/descendants.py
@@ -237,7 +237,7 @@ def find_descendants_by_filter(
     return descendants
 
 
-def hide_descendants_by_filter(host, endpoint, filter):
+def hide_descendants_by_filter(host, endpoint, filter, gf_acl=None):
     """
     Be aware that this and unhide_descendants_by_filter are not symmetrical.
 
@@ -248,7 +248,7 @@ def hide_descendants_by_filter(host, endpoint, filter):
     """
     desc = find_descendants_by_filter(host, endpoint, filter, False)
     for k, v in desc.items():
-        hide_kfids(host, v)
+        hide_kfids(host, v, gf_acl)
 
 
 def unhide_descendants_by_filter(host, endpoint, filter):
@@ -265,7 +265,7 @@ def unhide_descendants_by_filter(host, endpoint, filter):
         unhide_kfids(host, v)
 
 
-def hide_descendants_by_kfids(host, endpoint, kfids):
+def hide_descendants_by_kfids(host, endpoint, kfids, gf_acl=None):
     """
     Be aware that this and unhide_descendants_by_kfids are not symmetrical.
 
@@ -276,7 +276,7 @@ def hide_descendants_by_kfids(host, endpoint, kfids):
     """
     desc = find_descendants_by_kfids(host, endpoint, kfids, False)
     for k, v in desc.items():
-        hide_kfids(host, v)
+        hide_kfids(host, v, gf_acl)
 
 
 def unhide_descendants_by_kfids(host, endpoint, kfids):

--- a/kf_utils/dataservice/patch.py
+++ b/kf_utils/dataservice/patch.py
@@ -47,16 +47,18 @@ def patch_things_with_func(host, things, patch_func):
     send_patches(host, patches)
 
 
-def hide_kfids(host, kfid_list):
+def hide_kfids(host, kfid_list, gf_acl=None):
     """
     Hide a set of KFIDs
 
     :param host: dataservice base url string (e.g. "http://localhost:5000")
     :param kfid_list: list of kfids to hide
+    :param gf_acl: acl to set when hiding any genomic files
     """
+
     def hide_function(k):
         if prefix_endpoints[prefix(k)] == "genomic-files":
-            return {"visible": False, "acl": []}
+            return {"visible": False, "acl": gf_acl or []}
         else:
             return {"visible": False}
 


### PR DESCRIPTION
Options to return full descendant entities, not just kfids, and also to specify a GF acl when calling the hide functions.