### PR TITLE
✏️ Point README unhide_descendants_kfids to right func

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ hide_descendants_by_kfids(
 # Unhide these families and all of their descendants except for genomic files with
 # additional contributing specimens if those specimens will remain hidden.
 # This and hide_descendants_by_kfids are not symmetrical.
-unhide_descendants_kfids(api_url, "families", ["FM_12345678", "FM_87654321"], db_url=db_url)
+unhide_descendants_by_kfids(api_url, "families", ["FM_12345678", "FM_87654321"], db_url=db_url)
 ```
 
 #### [dataservice/patch.py](kf_utils/dataservice/patch.py) - Rapid patch submission


### PR DESCRIPTION
the readme points to unhide_descendants_kfids but the correct function is unhide_descendants_by_kfids.

- [x] fixup commits are appropriately squashed

points the readme to the correct function