### PR TITLE
👽 Bypass pip resolver's broken version check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-d3b_utils @ git+https://git@github.com/d3b-center/d3b-utils-python.git
+d3b_utils @ git+https://github.com/d3b-center/d3b-utils-python.git
 # defusedxml
 xmltodict
 psycopg2-binary


### PR DESCRIPTION
ERROR: Cannot install -r requirements.txt (line 17) and d3b-utils 0.1.0 (from git+https://github.com/d3b-center/d3b-utils-python.git) because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested d3b-utils 0.1.0 (from git+https://github.com/d3b-center/d3b-utils-python.git)
    kf-utils 0.1.2 depends on d3b-utils 0.1.0 (from git+https://****@github.com/d3b-center/d3b-utils-python.git)

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
