### PR TITLE
:recycle: Don't use retry Sessions

### DIFF
--- a/kf_utils/dataservice/delete.py
+++ b/kf_utils/dataservice/delete.py
@@ -2,7 +2,8 @@ from concurrent.futures import ThreadPoolExecutor
 from pprint import pformat
 from urllib.parse import urlparse
 
-from d3b_utils.requests_retry import Session
+# from d3b_utils.requests_retry import Session
+from requests import Session
 from kf_utils.dataservice.meta import get_endpoint
 from kf_utils.dataservice.scrape import yield_kfids
 

--- a/kf_utils/dataservice/patch.py
+++ b/kf_utils/dataservice/patch.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from d3b_utils.requests_retry import Session
+# from d3b_utils.requests_retry import Session
+from requests import Session
 from kf_utils.dataservice.meta import get_endpoint
 
 

--- a/kf_utils/dataservice/scrape.py
+++ b/kf_utils/dataservice/scrape.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from d3b_utils.requests_retry import Session
+# from d3b_utils.requests_retry import Session
+from requests import Session
 from kf_utils.dataservice.meta import get_endpoint
 from tqdm import tqdm
 

--- a/kf_utils/dbgap/release.py
+++ b/kf_utils/dbgap/release.py
@@ -1,5 +1,6 @@
 import xmltodict
-from d3b_utils.requests_retry import Session
+# from d3b_utils.requests_retry import Session
+from requests import Session
 from xml.etree import ElementTree
 
 # from defusedxml import ElementTree as DefusedET


### PR DESCRIPTION
This library uses retry sessions from d3b_utils but this makes debugging very difficult bc requests seem like they are hanging when really the session is just retrying. For now this branch is temporary, but we may consider using a normal Python requests Session without retries by default, while still giving the user the opportunity to use retry Sessions if they want.
