### PR TITLE
add sample relationships entities to utils

### DIFF
--- a/kf_utils/dataservice/delete.py
+++ b/kf_utils/dataservice/delete.py
@@ -19,6 +19,7 @@ ENDPOINTS = [
     "phenotypes",
     "diagnoses",
     "samples",
+    "sample-relationships",
     "participants",
     "family-relationships",
     "families",

--- a/kf_utils/dataservice/meta.py
+++ b/kf_utils/dataservice/meta.py
@@ -20,6 +20,7 @@ prefix_endpoints = {
     "SE": "sequencing-experiments",
     "SF": "study-files",
     "SG": "sequencing-experiment-genomic-files",
+    "SR": "sample-relationships",
     "TG": "task-genomic-files",
     "TK": "tasks",
 }


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed

[Description here]
relates to AD-1409,
adding sample-relationships endpoint so these can be patched to be made visible in support of vbr